### PR TITLE
Add real-time game timer with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, responsive X-O (Tic-Tac-Toe) game built with HTML5, CSS3, and vanilla 
 - **Responsive design**: Adapts to any screen size
 - **Score tracking**: Keep track of wins for both players
 - **Game persistence**: Automatically saves game state and scores across browser sessions
+- **Game timer**: Track how long each game takes with real-time display
 - **Dark mode**: Toggle between light and dark themes with persistent preference
 - **Modern UI**: Beautiful gradient design with smooth animations
 - **Haptic feedback**: Vibration on supported mobile devices
@@ -23,6 +24,7 @@ A modern, responsive X-O (Tic-Tac-Toe) game built with HTML5, CSS3, and vanilla 
 5. Use "Clear Score" to reset the scoreboard
 6. Use "Clear All Data" to reset everything (scores + current game)
 7. Click the 🌙/☀️ button in the top-right to toggle dark mode
+8. Watch the timer to see how fast you can complete each game
 
 ## 💾 Game Persistence
 
@@ -31,6 +33,7 @@ The game automatically saves your progress using browser localStorage:
 - **Scores persist** across browser sessions
 - **Game state is preserved** - you can refresh the page and continue where you left off
 - **Automatic saving** happens after every move, score update, and game reset
+- **Timer persistence** - game timer continues across page refreshes
 - **Data management** options:
   - "Clear Score" - resets only the scoreboard
   - "Clear All Data" - completely resets everything (new game + clear scores)
@@ -52,6 +55,7 @@ For the best mobile experience:
 - **Modern CSS**: Flexbox, Grid, CSS animations, and backdrop-filter
 - **ES6+ JavaScript**: Class-based architecture with modern syntax
 - **localStorage persistence**: Automatic game state and score saving
+- **Real-time timer**: Game timer with persistence across sessions
 - **Dark mode support**: CSS-based theme switching with smooth transitions
 - **Error handling**: Graceful fallback if localStorage is unavailable
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,10 @@
         <main>
             <div class="game-info">
                 <p id="currentPlayer">Player X's turn</p>
+                <div class="timer-display">
+                    <span class="timer-label">Game Time:</span>
+                    <span id="gameTimer" class="timer-value">00:00</span>
+                </div>
             </div>
 
             <div class="game-board" id="gameBoard">

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ class XOGame {
         this.currentPlayer = 'X';
         this.gameActive = true;
         this.scores = { X: 0, O: 0 };
+        this.gameStartTime = null;
+        this.timerInterval = null;
+        this.gameTime = 0;
         
         this.winningCombinations = [
             [0, 1, 2], [3, 4, 5], [6, 7, 8], // Rows
@@ -21,6 +24,7 @@ class XOGame {
     initializeElements() {
         this.cells = document.querySelectorAll('.cell');
         this.currentPlayerDisplay = document.getElementById('currentPlayer');
+        this.gameTimerDisplay = document.getElementById('gameTimer');
         this.scoreXDisplay = document.getElementById('scoreX');
         this.scoreODisplay = document.getElementById('scoreO');
         this.resetBtn = document.getElementById('resetBtn');
@@ -32,7 +36,7 @@ class XOGame {
         this.playAgainBtn = document.getElementById('playAgainBtn');
         
         // Validate that all required elements exist
-        if (!this.cells.length || !this.currentPlayerDisplay || !this.scoreXDisplay || 
+        if (!this.cells.length || !this.currentPlayerDisplay || !this.gameTimerDisplay || !this.scoreXDisplay || 
             !this.scoreODisplay || !this.resetBtn || !this.clearScoreBtn || 
             !this.clearAllDataBtn || !this.darkModeToggle || !this.gameOverModal || !this.gameOverMessage || !this.playAgainBtn) {
             console.error('Required game elements not found in DOM');
@@ -82,6 +86,12 @@ class XOGame {
     makeMove(index) {
         this.board[index] = this.currentPlayer;
         this.updateCell(index);
+        
+        // Start timer on first move
+        if (this.gameTime === 0 && !this.gameStartTime) {
+            this.startTimer();
+        }
+        
         this.saveGameState(); // Save after each move
         
         if (this.checkWin()) {
@@ -128,6 +138,7 @@ class XOGame {
     
     handleWin() {
         this.gameActive = false;
+        this.stopTimer();
         this.scores[this.currentPlayer]++;
         this.updateScores();
         this.saveGameState(); // Save after win
@@ -136,6 +147,7 @@ class XOGame {
     
     handleDraw() {
         this.gameActive = false;
+        this.stopTimer();
         this.saveGameState(); // Save after draw
         this.showGameOver("It's a Draw!");
     }
@@ -168,6 +180,7 @@ class XOGame {
         this.board = Array(9).fill('');
         this.currentPlayer = 'X';
         this.gameActive = true;
+        this.resetTimer();
         
         // Clear all cells
         this.cells.forEach(cell => {
@@ -193,7 +206,9 @@ class XOGame {
             board: this.board,
             currentPlayer: this.currentPlayer,
             gameActive: this.gameActive,
-            scores: this.scores
+            scores: this.scores,
+            gameTime: this.gameTime,
+            gameStartTime: this.gameStartTime
         };
         localStorage.setItem('xoGameState', JSON.stringify(gameState));
     }
@@ -207,10 +222,18 @@ class XOGame {
                 this.currentPlayer = gameState.currentPlayer || 'X';
                 this.gameActive = gameState.gameActive !== undefined ? gameState.gameActive : true;
                 this.scores = gameState.scores || { X: 0, O: 0 };
+                this.gameTime = gameState.gameTime || 0;
+                this.gameStartTime = gameState.gameStartTime || null;
                 
                 // Restore the visual state of the board
                 this.restoreBoardVisuals();
                 this.updateScores();
+                this.displayTimer();
+                
+                // Resume timer if game is active and timer was running
+                if (this.gameActive && this.gameStartTime && this.gameTime > 0) {
+                    this.startTimer();
+                }
             }
         } catch (error) {
             console.error('Error loading game state:', error);
@@ -219,6 +242,8 @@ class XOGame {
             this.currentPlayer = 'X';
             this.gameActive = true;
             this.scores = { X: 0, O: 0 };
+            this.gameTime = 0;
+            this.gameStartTime = null;
         }
     }
     
@@ -241,6 +266,7 @@ class XOGame {
         this.currentPlayer = 'X';
         this.gameActive = true;
         this.scores = { X: 0, O: 0 };
+        this.resetTimer();
         this.restoreBoardVisuals();
         this.updateScores();
         this.updateDisplay();
@@ -266,6 +292,45 @@ class XOGame {
         if (savedDarkMode === 'true') {
             document.body.classList.add('dark-mode');
         }
+    }
+    
+    // Timer methods
+    startTimer() {
+        if (this.timerInterval) {
+            clearInterval(this.timerInterval);
+        }
+        this.gameStartTime = Date.now();
+        this.timerInterval = setInterval(() => {
+            this.updateTimer();
+        }, 1000);
+    }
+    
+    stopTimer() {
+        if (this.timerInterval) {
+            clearInterval(this.timerInterval);
+            this.timerInterval = null;
+        }
+    }
+    
+    updateTimer() {
+        if (this.gameStartTime) {
+            this.gameTime = Math.floor((Date.now() - this.gameStartTime) / 1000);
+            this.displayTimer();
+        }
+    }
+    
+    displayTimer() {
+        const minutes = Math.floor(this.gameTime / 60);
+        const seconds = this.gameTime % 60;
+        const timeString = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        this.gameTimerDisplay.textContent = timeString;
+    }
+    
+    resetTimer() {
+        this.stopTimer();
+        this.gameTime = 0;
+        this.gameStartTime = null;
+        this.displayTimer();
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -299,7 +299,7 @@ class XOGame {
         if (this.timerInterval) {
             clearInterval(this.timerInterval);
         }
-        this.gameStartTime = Date.now();
+        this.gameStartTime = Date.now() - (this.gameTime * 1000);
         this.timerInterval = setInterval(() => {
             this.updateTimer();
         }, 1000);

--- a/style.css
+++ b/style.css
@@ -79,6 +79,31 @@ h1 {
     background: #e3f2fd;
     border-radius: 25px;
     display: inline-block;
+    margin-bottom: 10px;
+}
+
+.timer-display {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: #f0f8ff;
+    border-radius: 20px;
+    border: 2px solid #e3f2fd;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.timer-label {
+    color: #555;
+}
+
+.timer-value {
+    color: #667eea;
+    font-family: 'Courier New', monospace;
+    font-weight: 700;
+    font-size: 1.1rem;
 }
 
 /* Game board */
@@ -406,6 +431,19 @@ body.dark-mode .game-info p {
     background: #2a2a3e;
     color: #e0e0e0;
     border: 1px solid #3a3a4e;
+}
+
+body.dark-mode .timer-display {
+    background: #2a2a3e;
+    border: 2px solid #3a3a4e;
+}
+
+body.dark-mode .timer-label {
+    color: #b0b0b0;
+}
+
+body.dark-mode .timer-value {
+    color: #64b5f6;
 }
 
 body.dark-mode .game-board {


### PR DESCRIPTION
- Add timer display showing MM:SS format
- Start timer automatically on first move
- Stop timer when game ends (win/draw)
- Persist timer state across page refreshes
- Style timer for both light and dark modes
- Reset timer on new game and clear all data
- Update README with timer documentation
- Timer continues from saved state when resuming games