### PR TITLE
Add custom board size feature with dynamic win detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern, responsive X-O (Tic-Tac-Toe) game built with HTML5, CSS3, and vanilla 
 - **Score tracking**: Keep track of wins for both players
 - **Game persistence**: Automatically saves game state and scores across browser sessions
 - **Game timer**: Track how long each game takes with real-time display
+- **Custom board sizes**: Choose from 3x3, 4x4, 5x5, or 6x6 boards
 - **Dark mode**: Toggle between light and dark themes with persistent preference
 - **Modern UI**: Beautiful gradient design with smooth animations
 - **Haptic feedback**: Vibration on supported mobile devices
@@ -25,6 +26,7 @@ A modern, responsive X-O (Tic-Tac-Toe) game built with HTML5, CSS3, and vanilla 
 6. Use "Clear All Data" to reset everything (scores + current game)
 7. Click the 🌙/☀️ button in the top-right to toggle dark mode
 8. Watch the timer to see how fast you can complete each game
+9. Select different board sizes for varied gameplay (3x3 to 6x6)
 
 ## 💾 Game Persistence
 
@@ -34,6 +36,7 @@ The game automatically saves your progress using browser localStorage:
 - **Game state is preserved** - you can refresh the page and continue where you left off
 - **Automatic saving** happens after every move, score update, and game reset
 - **Timer persistence** - game timer continues across page refreshes
+- **Board size preference** - your chosen board size is saved and restored
 - **Data management** options:
   - "Clear Score" - resets only the scoreboard
   - "Clear All Data" - completely resets everything (new game + clear scores)
@@ -56,6 +59,7 @@ For the best mobile experience:
 - **ES6+ JavaScript**: Class-based architecture with modern syntax
 - **localStorage persistence**: Automatic game state and score saving
 - **Real-time timer**: Game timer with persistence across sessions
+- **Dynamic board generation**: Supports multiple board sizes with adaptive win detection
 - **Dark mode support**: CSS-based theme switching with smooth transitions
 - **Error handling**: Graceful fallback if localStorage is unavailable
 

--- a/index.html
+++ b/index.html
@@ -50,9 +50,20 @@
             </div>
 
             <div class="game-controls">
-                <button id="resetBtn" class="btn">New Game</button>
-                <button id="clearScoreBtn" class="btn secondary">Clear Score</button>
-                <button id="clearAllDataBtn" class="btn secondary">Clear All Data</button>
+                <div class="board-size-selector">
+                    <label for="boardSize">Board Size:</label>
+                    <select id="boardSize" class="board-size-select">
+                        <option value="3">3x3 (Classic)</option>
+                        <option value="4">4x4</option>
+                        <option value="5">5x5</option>
+                        <option value="6">6x6</option>
+                    </select>
+                </div>
+                <div class="control-buttons">
+                    <button id="resetBtn" class="btn">New Game</button>
+                    <button id="clearScoreBtn" class="btn secondary">Clear Score</button>
+                    <button id="clearAllDataBtn" class="btn secondary">Clear All Data</button>
+                </div>
             </div>
         </main>
 

--- a/style.css
+++ b/style.css
@@ -187,6 +187,52 @@ h1 {
 /* Game controls */
 .game-controls {
     display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+}
+
+.board-size-selector {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 15px;
+    background: #f8f9fa;
+    border-radius: 15px;
+    border: 2px solid #e9ecef;
+}
+
+.board-size-selector label {
+    font-weight: 600;
+    color: #555;
+    font-size: 0.9rem;
+}
+
+.board-size-select {
+    padding: 8px 12px;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    background: white;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #333;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.board-size-select:hover {
+    border-color: #667eea;
+    transform: translateY(-1px);
+}
+
+.board-size-select:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.control-buttons {
+    display: flex;
     gap: 15px;
     justify-content: center;
     flex-wrap: wrap;
@@ -474,6 +520,30 @@ body.dark-mode .btn.secondary {
 body.dark-mode .btn.secondary:hover {
     background: #3a3a4e;
     color: #e0e0e0;
+}
+
+body.dark-mode .board-size-selector {
+    background: #2a2a3e;
+    border: 2px solid #3a3a4e;
+}
+
+body.dark-mode .board-size-selector label {
+    color: #b0b0b0;
+}
+
+body.dark-mode .board-size-select {
+    background: #2a2a3e;
+    border: 2px solid #3a3a4e;
+    color: #e0e0e0;
+}
+
+body.dark-mode .board-size-select:hover {
+    border-color: #64b5f6;
+}
+
+body.dark-mode .board-size-select:focus {
+    border-color: #64b5f6;
+    box-shadow: 0 0 0 3px rgba(100, 181, 246, 0.1);
 }
 
 body.dark-mode .modal-content {


### PR DESCRIPTION
- Add board size selector (3x3, 4x4, 5x5, 6x6)
- Implement dynamic board generation with CSS Grid
- Update win detection algorithm for all board sizes
- Generate winning combinations dynamically for any size
- Persist board size preference in localStorage
- Style board size selector for both light and dark modes
- Update README with board size documentation
- Maintain all existing functionality across board sizes